### PR TITLE
Update to v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Legend:
 
 ## v1.2.1 - 2025-01-28
 
+### Codename: `Hotfix: MissingNoSettings`
+
 * 🐛 Fixed upgrading from previous versions breaking the Dummy's behavior.
 * 🔧 Added versioning system to keep track of when the user upgrades their world's datapack from a previous version.
   * For the sake of retroactively fixing previous versions' issues with missing settings, the local version is set to a version behind the latest upon first load. This will be fixed within the next update.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Legend:
 > 🔺 Enhancement  
 > 🔧 Technical
 
+## v1.2.1 - 2025-01-28
+
+* 🐛 Fixed upgrading from previous versions breaking the Dummy's behavior.
+* 🔧 Added versioning system to keep track of when the user upgrades their world's datapack from a previous version.
+  * For the sake of retroactively fixing previous versions' issues with missing settings, the local version is set to a version behind the latest upon first load. This will be fixed within the next update.
+
 ## v1.2.0 - 2025-01-27
 
 ### Codename: `Seeker`

--- a/data/lumenfuchs/function/load.mcfunction
+++ b/data/lumenfuchs/function/load.mcfunction
@@ -1,4 +1,4 @@
-## * AydenTFoxx @ 2025-01-11 .. 2025-01-13
+## * AydenTFoxx @ 2025-01-11 .. 2025-01-28
 ## * 
 ## * Initializes features required for the proper functioning of the datapack.
 
@@ -6,7 +6,7 @@
 ## # INIT
 
 # Wait until Player is loaded
-execute unless entity @e[type=player] run return run schedule function lumenfuchs:load 20t
+execute unless entity @n[type=player] run return run schedule function lumenfuchs:load 20t
 
 # Display join message
 execute unless data storage lumenfuchs:flags { first_load_true: true } run tellraw @a { "translate": "%s has joined the world.", "color": "yellow", "with": [ { "selector": "@p" } ], "hoverEvent": { "action": "show_text", "contents": [ "First time here? Try running ", { "text": "/function lumenfuchs:help", "color": "yellow" }, " for a start!" ] }, "clickEvent": { "action": "suggest_command", "value": "/trigger lumenfuchs.settings set 200" } }
@@ -63,6 +63,24 @@ scoreboard players enable @a lumenfuchs.settings
 
 
 ## # FLAGS
+
+# Set datapack latest version
+# 1 - 1.0.0
+# 2 - 1.1.0
+# 3 - 1.1.1
+# 4 - 1.2.0
+# 5 - 1.2.1
+scoreboard players set #lumenfuchs_dummy.target_version lumenfuchs.dummy 5
+
+# Set current version to one behind latest
+execute unless score #lumenfuchs_dummy.current_version lumenfuchs.dummy matches 1.. \
+        run scoreboard players set #lumenfuchs_dummy.current_version lumenfuchs.dummy 4
+
+
+# Update to latest version
+execute if score #lumenfuchs_dummy.current_version lumenfuchs.dummy < #lumenfuchs_dummy.target_version lumenfuchs.dummy \
+        run return run function lumenfuchs:upgrade_version
+
 
 # Initialize settings
 execute unless data storage lumenfuchs:flags { first_load: true } run function lumenfuchs:load_settings

--- a/data/lumenfuchs/function/upgrade_version.mcfunction
+++ b/data/lumenfuchs/function/upgrade_version.mcfunction
@@ -1,0 +1,17 @@
+## * AydenTFoxx @ 2025-01-28
+## * 
+## * Upgrades the datapack's version to the latest, then forces a "reload" of its settings.
+
+
+# Remove first load flag
+data remove storage lumenfuchs:flags first_load
+
+# DEBUG: Display feedback
+execute if data storage lumenfuchs:flags { debug_mode: true } run tellraw @a [{ "text": "[" }, { "text": "The Dummy", "bold": true, "hoverEvent": { "action": "show_text", "contents": [{ "text": "Datapack: " }, { "text": "YNHZRFXN", "color": "black", "obfuscated": true }] } }, { "translate": "] Updating datapack version to %s.", "with": [ { "score": { "name": "#lumenfuchs_dummy.target_version", "objective": "lumenfuchs.dummy" } } ] }]
+
+
+# Update to latest
+scoreboard players operation #lumenfuchs_dummy.current_version lumenfuchs.dummy = #lumenfuchs_dummy.target_version lumenfuchs.dummy
+
+# Reload datapack
+function lumenfuchs:load


### PR DESCRIPTION
+ Added `#lumenfuchs_dummy.target_version` (updated on every datapack update), which tells the datapack which version it should be at.
+ Added `#lumenfuchs_dummy.current_version` (updated when loading a world), which keeps track of the version the datapack was last played at.
+ If both versions differ, the datapack's `first_load` flag is removed and a re-load of the datapack is run.
+ Updated Changelog accordingly.