### PR TITLE
Update to v1.5.1

### DIFF
--- a/BP/data/dummy_lib/tags/block/transparent.json
+++ b/BP/data/dummy_lib/tags/block/transparent.json
@@ -30,6 +30,7 @@
         "tripwire",
         "tripwire_hook",
         "kelp",
-        "kelp_plant"
+        "kelp_plant",
+        "firefly_bush"
     ]
 }

--- a/BP/data/lumenfuchs/function/dummy/events/attack.mcfunction
+++ b/BP/data/lumenfuchs/function/dummy/events/attack.mcfunction
@@ -1,4 +1,4 @@
-## * AydenTFoxx @ 2025-01-15 .. 2025-03-02
+## * AydenTFoxx @ 2025-01-15 .. 2025-04-02
 ## * 
 ## * Performs the dummy's signature "attack" ability.
 
@@ -8,6 +8,8 @@ stopsound @a[distance=..64]
 
 # Damage nearest victim
 execute if entity @p[gamemode=!creative, gamemode=!spectator, distance=..64] run damage @p[gamemode=!creative, gamemode=!spectator, distance=..64] 8 sonic_boom by @s
+execute as @p[gamemode=!creative, gamemode=!spectator, distance=..64] if score @s lumenfuchs.purity matches ..-16 run effect give @s wither 4 2
+
 execute unless entity @p[gamemode=!creative, gamemode=!spectator, distance=..64] as @e[type=!#dummy_lib:technical, distance=..16] run damage @s 8 sonic_boom by @n[type=interaction, tag=lumenfuchs.entity.dummy]
 
 

--- a/BP/data/lumenfuchs/function/dummy/events/teleport/dimension.mcfunction
+++ b/BP/data/lumenfuchs/function/dummy/events/teleport/dimension.mcfunction
@@ -1,4 +1,4 @@
-## * AydenTFoxx @ 2025-03-02 .. 2025-03-04
+## * AydenTFoxx @ 2025-03-02 .. 2025-04-02
 ## * 
 ## * Tunnels through all non-unbreakable terrain until the Dummy hits the Void.
 ## * Used whenever the Dummy is stuck in a dimension where no other player is present.
@@ -31,7 +31,7 @@ execute if score @s dummy_lib.dummy matches 180 run playsound entity.wither.deat
 
 # Set natural spawning trigger to random player
 execute if score @s dummy_lib.dummy matches 180 as @r unless score @s dummy_lib.dummy matches 4000.. \
-		run scoreboard players set @s dummy_lib.dummy 4000
+		unless score @s lumenfuchs.purity matches 12.. run scoreboard players set @s dummy_lib.dummy 4000
 
 
 # Build Shrine at initial position

--- a/BP/data/lumenfuchs/function/dummy/events/teleport/distance.mcfunction
+++ b/BP/data/lumenfuchs/function/dummy/events/teleport/distance.mcfunction
@@ -1,4 +1,4 @@
-## * AydenTFoxx @ 2025-03-04
+## * AydenTFoxx @ 2025-03-04 .. 2025-04-02
 ## * 
 ## * "Respawns" the Dummy near a random/nearest player, with the same health it had beforehand.
 ## * Used whenever the Dummy is stuck and cannot target any player within its staring range.
@@ -16,7 +16,8 @@ function lumenfuchs:dummy/events/teleport/_prepare
 
 
 # Spawn anchor
-execute if score @s dummy_lib.dummy matches 200.. at @p[gamemode=!spectator] run function lumenfuchs:dummy/events/spawn/try_spawning
+execute if score @s dummy_lib.dummy matches 200.. as @p[gamemode=!spectator] at @s \
+		unless score @s lumenfuchs.purity matches 12.. run function lumenfuchs:dummy/events/spawn/try_spawning
 
 
 # Set health of new Dummy

--- a/BP/data/lumenfuchs/function/dummy/update_b.mcfunction
+++ b/BP/data/lumenfuchs/function/dummy/update_b.mcfunction
@@ -1,4 +1,4 @@
-## * AydenTFoxx @ 2025-01-13 .. 2025-03-02
+## * AydenTFoxx @ 2025-01-13 .. 2025-04-02
 ## * 
 ## * Updates the Dummy with entity-like and custom behavior.
 
@@ -85,8 +85,9 @@ execute if score @s dummy_lib.dummy matches 20.. if entity @p[distance=0..] run 
 
 ## Attack
 
-# Harm non-player entities
-execute if data storage lumenfuchs:flags { dummy: { harm_on_touch: true } } run damage @n[type=!#dummy_lib:technical, distance=..1] 2 thorns by @s
+# Harm non-player entities (ignored by Purity)
+execute if data storage lumenfuchs:flags { dummy: { harm_on_touch: true } } as @e[type=!#dummy_lib:technical, distance=..1] \
+		unless score @s lumenfuchs.purity matches 12.. run damage @s 2 thorns by @n[type=interaction, tag=lumenfuchs.entity.dummy, distance=..2]
 
 
 # Prepare attack

--- a/BP/data/lumenfuchs/function/items/dummy_attack/release_a.mcfunction
+++ b/BP/data/lumenfuchs/function/items/dummy_attack/release_a.mcfunction
@@ -1,4 +1,4 @@
-## * AydenTFoxx @ 2025-03-05 .. 2025-04-01
+## * AydenTFoxx @ 2025-03-05 .. 2025-04-02
 ## * 
 ## * Executes a single-target Dummy blast a few blocks ahead of the player.
 ## ? This variant deals damage to the closest creature to the target position.
@@ -41,6 +41,11 @@ playsound ambient.crimson_forest.mood master @a[distance=..32] ~ ~ ~ 0.5 0.8 0.1
 # Spawn Evoker Fang
 execute anchored eyes positioned ^ ^-1 ^4 align y if block ~ ~ ~ #dummy_lib:transparent \
 		unless entity @s[distance=..1] run summon evoker_fangs ~ ~ ~
+
+# Inflict debuff (low Purity)
+execute anchored eyes positioned ^ ^-1 ^4 align y if block ~ ~ ~ #dummy_lib:transparent \
+		if entity @s[distance=1.., scores={ lumenfuchs.purity=..-16 }] run effect give @n[type=!#dummy_lib:technical, distance=..3, limit=3] wither 4 2
+
 
 # Remove Purity
 execute if predicate dummy_lib:random/10 run function lumenfuchs:dummy/utils/revoke_purity with entity @s

--- a/BP/data/lumenfuchs/function/items/dummy_attack/release_b.mcfunction
+++ b/BP/data/lumenfuchs/function/items/dummy_attack/release_b.mcfunction
@@ -1,4 +1,4 @@
-## * AydenTFoxx @ 2025-03-05 .. 2025-04-01
+## * AydenTFoxx @ 2025-03-05 .. 2025-04-02
 ## * 
 ## * Executes an AoE Dummy blast a few blocks ahead of the player.
 ## ? This variant deals damage to all creatures around the target position.
@@ -50,6 +50,11 @@ execute anchored eyes positioned ^ ^-1 ^4 align y if block ~ ~ ~ #dummy_lib:tran
 
 execute anchored eyes positioned ^ ^-1 ^4 align y if block ~ ~ ~ #dummy_lib:transparent \
 		unless entity @s[distance=..1] run summon evoker_fangs ~0.5 ~ ~-0.5
+
+# Spawn Lightning (low Purity)
+execute anchored eyes positioned ^ ^-1 ^4 align y if block ~ ~ ~ #dummy_lib:transparent \
+		if entity @s[distance=1.., scores={ lumenfuchs.purity=..-16 }] run summon lightning_bolt ~ ~ ~
+
 
 # Remove Purity
 execute if predicate dummy_lib:random/20 run function lumenfuchs:dummy/utils/revoke_purity with entity @s

--- a/BP/data/lumenfuchs/function/load.mcfunction
+++ b/BP/data/lumenfuchs/function/load.mcfunction
@@ -53,7 +53,7 @@ scoreboard players enable @a lumenfuchs.settings
 # 5 | 1.2.1 - 1.2.2
 # 6 | 1.3.0 - 1.3.1
 # 7 | 1.4.0
-# 8 | 1.5.0
+# 8 | 1.5.0 - 1.5.1
 scoreboard players set #lumenfuchs_dummy.target_version dummy_lib.dummy 8
 
 # Set current version to latest

--- a/BP/data/lumenfuchs/function/seeker/summon.mcfunction
+++ b/BP/data/lumenfuchs/function/seeker/summon.mcfunction
@@ -1,4 +1,4 @@
-## * AydenTFoxx @ 2025-01-27 .. 2025-04-01
+## * AydenTFoxx @ 2025-01-27 .. 2025-04-02
 ## * 
 ## * Summons a Dummy-like entity with a Carved Pumpkin on its head.
 
@@ -9,7 +9,7 @@ summon interaction ~0.5 ~ ~0.5 { \
 	CustomName: { "text": "LKRLSLPN", "color": "black", "obfuscated": true }, \
 	CustomNameVisible: false, \
 	response: false, \
-	Tags: [ dummy_lib.entity, dummy_lib.entity.seeker ], \
+	Tags: [ dummy_lib.entity, lumenfuchs.entity.seeker ], \
 	height: 1.8, \
 	width: 0.8 \
 }
@@ -113,7 +113,7 @@ summon item_display ~0.5 ~1.6 ~0.5 { \
 
 
 ## Set Health
-execute as @e[type=interaction, tag=dummy_lib.entity.seeker, distance=..1] unless score @s dummy_lib.guid matches 1.. run scoreboard players set @s dummy_lib.health 8
+execute as @e[type=interaction, tag=lumenfuchs.entity.seeker, distance=..1] unless score @s dummy_lib.guid matches 1.. run scoreboard players set @s dummy_lib.health 8
 
 ## Set Materials
 execute positioned ~0.5 ~1 ~0.5 as @n[type=item_display, tag=dummy_lib.dummy_limb.torso, distance=..2] \
@@ -137,6 +137,6 @@ execute positioned ~0.5 ~1 ~0.5 as @e[type=item_display, tag=dummy_lib.entity.du
 		unless score @s dummy_lib.guid matches 1.. \
 		run scoreboard players operation @s dummy_lib.guid = #dummy_lib_guid dummy_lib.guid
 
-execute as @e[type=interaction, tag=dummy_lib.entity.seeker, distance=..1] unless score @s dummy_lib.guid matches 1.. run scoreboard players operation @s dummy_lib.guid = #dummy_lib_guid dummy_lib.guid
+execute as @e[type=interaction, tag=lumenfuchs.entity.seeker, distance=..1] unless score @s dummy_lib.guid matches 1.. run scoreboard players operation @s dummy_lib.guid = #dummy_lib_guid dummy_lib.guid
 
 scoreboard players add #dummy_lib_guid dummy_lib.guid 1

--- a/BP/data/lumenfuchs/function/seeker/update_b.mcfunction
+++ b/BP/data/lumenfuchs/function/seeker/update_b.mcfunction
@@ -1,4 +1,4 @@
-## * AydenTFoxx @ 2025-01-27 .. 2025-03-04
+## * AydenTFoxx @ 2025-01-27 .. 2025-04-02
 ## * 
 ## * Updates the Seeker with entity-like and custom behavior.
 
@@ -73,5 +73,6 @@ execute if entity @s[tag=dummy_lib.dummy.is_walking, tag=!lumenfuchs.dummy.looke
 
 ## Attack
 
-# Harm non-player entities
-execute if data storage lumenfuchs:flags { dummy: { harm_on_touch: true } } run damage @n[type=!#dummy_lib:technical, distance=..1] 2 thorns by @s
+# Harm non-player entities (ignored by Purity)
+execute if data storage lumenfuchs:flags { dummy: { harm_on_touch: true } } as @e[type=!#dummy_lib:technical, distance=..1] \
+		unless score @s lumenfuchs.purity matches 12.. run damage @s 2 thorns by @n[type=interaction, tag=lumenfuchs.entity.dummy, distance=..2]

--- a/BP/data/lumenfuchs/function/tick.mcfunction
+++ b/BP/data/lumenfuchs/function/tick.mcfunction
@@ -1,4 +1,4 @@
-## * AydenTFoxx @ 2025-01-15 .. 2025-03-04
+## * AydenTFoxx @ 2025-01-15 .. 2025-04-02
 ## * 
 ## * Ticks all code from this datapack at a custom rate.
 
@@ -14,8 +14,8 @@ scoreboard players add #lumenfuchs_tick_b dummy_lib.dummy 1
 execute if score #lumenfuchs_tick_a dummy_lib.dummy = #lumenfuchs_tick_rate_a dummy_lib.dummy as @e[type=interaction, tag=lumenfuchs.entity.dummy] at @s run function lumenfuchs:dummy/update_a with storage lumenfuchs:flags dummy
 execute if score #lumenfuchs_tick_b dummy_lib.dummy = #lumenfuchs_tick_rate_b dummy_lib.dummy as @e[type=interaction, tag=lumenfuchs.entity.dummy, tag=!dummy_lib.dummy.is_dead] at @s if loaded ~ ~ ~ run function lumenfuchs:dummy/update_b with storage lumenfuchs:flags dummy
 
-execute if score #lumenfuchs_tick_a dummy_lib.dummy = #lumenfuchs_tick_rate_a dummy_lib.dummy as @e[type=interaction, tag=dummy_lib.entity.seeker] at @s run function lumenfuchs:seeker/update_a with storage lumenfuchs:flags dummy
-execute if score #lumenfuchs_tick_b dummy_lib.dummy = #lumenfuchs_tick_rate_b dummy_lib.dummy as @e[type=interaction, tag=dummy_lib.entity.seeker, tag=!dummy_lib.dummy.is_dead] at @s if loaded ~ ~ ~ run function lumenfuchs:seeker/update_b with storage lumenfuchs:flags dummy
+execute if score #lumenfuchs_tick_a dummy_lib.dummy = #lumenfuchs_tick_rate_a dummy_lib.dummy as @e[type=interaction, tag=lumenfuchs.entity.seeker] at @s run function lumenfuchs:seeker/update_a with storage lumenfuchs:flags dummy
+execute if score #lumenfuchs_tick_b dummy_lib.dummy = #lumenfuchs_tick_rate_b dummy_lib.dummy as @e[type=interaction, tag=lumenfuchs.entity.seeker, tag=!dummy_lib.dummy.is_dead] at @s if loaded ~ ~ ~ run function lumenfuchs:seeker/update_b with storage lumenfuchs:flags dummy
 
 
 # Reset clock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,23 @@ Legend:
 > 🔺 Enhancement  
 > 🔧 Technical
 
+## v1.5.1 - 2025-04-02
+
+### Codename: `Hotfix: Folly`
+
+* ✳️ Created new branch for 1.21.2 to 1.21.4-compatible versions of the datapack (`devel-1.21.4`)
+  * Releases will now come in two flavors: `1.21.4-` (1.21.2 - 1.21.4) and `1.21.5+` (1.21.5 and above); Versions outside this range remain unsupported.
+    * This effectively keeps *Lumenfuchs' Dummy* as a 1.21.2+ project as it's always been. Happy April y'all :)
+* 🐛 Fixed translation keys for the Void Shard item being absent in both translation files.
+* 🔺 Changed impact of Purity on both extremes:
+  * High levels of Purity now prevent the Dummy from warping to the player; The player is also immune to the Dummy's "thorns" damage.
+    * The Dummy may still pathfind towards high-Purity players, however.
+  * The lowest levels of Purity now make the Void Shard even deadlier than before, but make the Dummy's attack *also* deadlier to the player!
+* 🔧 Fixed Seeker's unique tag prefixed with DummyLib's namespace rather than Lumenfuchs's. (i.e. `dummy_lib.entity.seeker` -> `lumenfuchs.entity.seeker`)
+
 ## v1.5.0 - 2025-04-01
 
-### Codename: `Ascent`
+### Codename: `Ascension`
 
 * ✳️ Added "Hotfix: " prefix to PATCH releases in the changelog for better consistency.
 * ✳️ Updated icons for both the Datapack and Resource Pack.

--- a/RP/assets/lumenfuchs/lang/en_us.json
+++ b/RP/assets/lumenfuchs/lang/en_us.json
@@ -27,6 +27,9 @@
     "item.lumenfuchs.settings_book": "Write me!",
     "item.lumenfuchs.settings_book.lore": "Editing setting \"%s\".",
 
+    "item.lumenfuchs.dummy_attack": "Void Shard",
+    "item.lumenfuchs.dummy_attack.description": "\"A shard of the Dummy's grim power.\"",
+
 
     "lumenfuchs.help.1": "Hello! Welcome to %s,\n a datapack whose main feature is the titular %s,",
     "lumenfuchs.help.2": "an \"entity\" whose main hobby is to stalk you around,\n no matter how, no matter where.",

--- a/RP/assets/lumenfuchs/lang/pt_br.json
+++ b/RP/assets/lumenfuchs/lang/pt_br.json
@@ -27,6 +27,9 @@
     "item.lumenfuchs.settings_book": "Escreva-me!",
     "item.lumenfuchs.settings_book.lore": "Editando configuração \"%s\".",
 
+    "item.lumenfuchs.dummy_attack": "Fragmento do Vazio",
+    "item.lumenfuchs.dummy_attack.lore": "\"Uma fração do poder sombrio do Dummy.\"",
+
 
     "lumenfuchs.help.1": "Olá! Bem-vindo a %s,\n um datapack cujo item principal é o %s,",
     "lumenfuchs.help.2": "uma \"entidade\" cujo passatempo principal é te observar e perseguir,\n não importa como, não importa onde.",


### PR DESCRIPTION
* Added `firefly_bush` to `#dummy_lib:transparent` block tag
* Changed `dummy_lib.entity.seeker` entity tag to `lumenfuchs.entity.seeker`
* High levels of Purity now prevent thorns damage from Dummy and Seeker; The Dummy can no longer Warp to high-Purity players
* Low levels of Purity now make the Dummy's attack and the Void Shard's ability much stronger
* Added changelog for latest release version
* Fixed v1.5.0's codename